### PR TITLE
Toggle input method

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@
               :useKilos="useKilos"
               :stats.sync="stats"
               :gender.sync="gender"
+              :inputLifts.sync="inputLifts"
             />
           </v-flex>
           <v-flex sm6 xs12>
@@ -38,6 +39,7 @@ import { Stat } from '@/models/Stat'
 export default class App extends Vue {
   useKilos: boolean = true
   gender: 'male' | 'female' = 'male'
+  inputLifts: boolean = true // Input individual lifts as opposed to just the total
 
   /**
    * List of user stats available as inputs. The first stat

--- a/src/App.vue
+++ b/src/App.vue
@@ -85,6 +85,17 @@ export default class App extends Vue {
       return { ...stat, value }
     })
   }
+
+  /**
+   * Toggle between inputting lifts individually vs. inputting total directly.
+   */
+  @Watch('inputLifts')
+  toggleInputs() {
+    const newStats = this.inputLifts
+      ? [{ name: 'squat', value: 0 }, { name: 'bench', value: 0 }, { name: 'deadlift', value: 0 }]
+      : [{ name: 'total', value: 0 }]
+    this.stats = [this.stats[0], ...newStats]
+  }
 }
 
 /**

--- a/src/components/LiftRank.vue
+++ b/src/components/LiftRank.vue
@@ -7,11 +7,11 @@
         <span class="subheading">{{ rank(stats) }}</span>
       </v-flex>
 
-      <v-flex 
-        sm3 xs12 mb-3 
-        v-for="stat in stats" 
-        :key="stat.name" 
-        v-if="stat.value"
+      <v-flex
+        sm3 xs12 mb-3
+        v-for="stat in stats"
+        :key="stat.name"
+        v-if="stat.value && stat.name !== 'total'"
         class="single-lift-score"
       >
         <span>{{ stat.name }}: {{ stat.value.toFixed(2) }}</span><br>

--- a/src/components/UserInputs.vue
+++ b/src/components/UserInputs.vue
@@ -20,8 +20,7 @@
     <!-- Toggle individual inputs / entering total directly -->
     <v-checkbox
       label="Input individual lifts."
-      :value="inputLifts"
-      @change="updateInputs"
+      v-model="inputLiftsMode"
     ></v-checkbox>
   </v-form>
 </template>
@@ -59,9 +58,11 @@ export default class UserInputs extends Vue {
     return payload
   }
 
-  @Emit('update:inputLifts')
-  updateInputs(): boolean {
-    return !this.inputLifts
+  get inputLiftsMode(): boolean {
+    return this.inputLifts
+  }
+  set inputLiftsMode(input: boolean) {
+    this.$emit('update:inputLifts', !this.inputLifts)
   }
 }
 </script>

--- a/src/components/UserInputs.vue
+++ b/src/components/UserInputs.vue
@@ -6,6 +6,7 @@
       <v-radio label="Female" value="female"></v-radio>
       <span><!-- Empty span fixes alignment bug --></span>
     </v-radio-group>
+
     <!-- Stats number inputs -->
     <v-text-field
       v-for="(stat, index) in stats"
@@ -15,6 +16,13 @@
       @input="updateStats(index, $event)"
       :label="label(stat.name)"
     ></v-text-field>
+
+    <!-- Toggle individual inputs / entering total directly -->
+    <v-checkbox
+      label="Input individual lifts."
+      :value="inputLifts"
+      @change="updateInputs"
+    ></v-checkbox>
   </v-form>
 </template>
 
@@ -33,6 +41,9 @@ export default class UserInputs extends Vue {
   @Prop(String)
   gender!: string
 
+  @Prop(Boolean)
+  inputLifts!: boolean
+
   // Add the measurement unit to the lift label
   label(tag: string): string {
     return tag + (this.useKilos ? ' (kg)' : ' (lbs)')
@@ -46,6 +57,11 @@ export default class UserInputs extends Vue {
   @Emit('update:gender')
   updateGender(payload: string): string {
     return payload
+  }
+
+  @Emit('update:inputLifts')
+  updateInputs(): boolean {
+    return !this.inputLifts
   }
 }
 </script>

--- a/tests/unit/LiftRank.spec.ts
+++ b/tests/unit/LiftRank.spec.ts
@@ -63,4 +63,9 @@ describe('Individual lift scores', () => {
     expect(individualLifts).toHaveLength(1)
   })
 
+  it('does not render total as an individual lift', () => {
+    const wrapper = shallowMount(LiftRank, { propsData: { stats: [{ name: 'total', value: 500 }] }})
+    const individualLifts = wrapper.findAll('.single-lift-score')
+    expect(individualLifts).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
Allow the user to toggle between entering individual lifts or entering the total directly.

Do not display a lift breakdown for the total.